### PR TITLE
bugfix: revert pr#3 and fix connections being closed during TableConn…

### DIFF
--- a/session/meta_session.go
+++ b/session/meta_session.go
@@ -15,7 +15,7 @@ import (
 )
 
 // MetaManager manages the list of metas, but only the leader will it requests to.
-// If the one is not the actual leader, it will retry with another one.
+// If the one is not the actual leader, it will retry with another.
 type MetaManager struct {
 	logger pegalog.Logger
 

--- a/session/replica_session.go
+++ b/session/replica_session.go
@@ -128,22 +128,3 @@ func (rm *ReplicaManager) ReplicaCount() int {
 
 	return len(rm.replicas)
 }
-
-func (rm *ReplicaManager) RemoveUnused(inused map[string]bool) {
-	rm.Lock()
-	defer rm.Unlock()
-
-	unused := make([]string, 0)
-
-	for addr, r := range rm.replicas {
-		if _, ok := inused[addr]; !ok {
-			// close if it's not inused.
-			r.Close()
-			unused = append(unused, addr)
-		}
-	}
-
-	for _, addr := range unused {
-		delete(rm.replicas, addr)
-	}
-}

--- a/session/replica_session_test.go
+++ b/session/replica_session_test.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"testing"
-	"time"
 
 	"github.com/fortytw2/leaktest"
 	"github.com/stretchr/testify/assert"
@@ -25,39 +24,10 @@ func TestReplicaManager_Close(t *testing.T) {
 	defer leaktest.Check(t)()
 
 	rm := NewReplicaManager()
-	defer rm.Close()
 
 	rm.GetReplica("127.0.0.1:34801")
 	rm.GetReplica("127.0.0.1:34802")
 	rm.GetReplica("127.0.0.1:34803")
 
-	time.Sleep(time.Second)
-}
-
-func TestReplicaManager_RemoveUnused(t *testing.T) {
-	defer leaktest.Check(t)()
-
-	rm := NewReplicaManager()
-	defer rm.Close()
-
-	{
-		r1 := rm.GetReplica("127.0.0.1:34802")
-		assert.Equal(t, len(rm.replicas), 1)
-
-		rm.RemoveUnused(map[string]bool{})
-		assert.Equal(t, len(rm.replicas), 0)
-
-		r2 := rm.GetReplica("127.0.0.1:34802")
-		assert.NotEqual(t, r1, r2)
-	}
-
-	{
-		rm.GetReplica("127.0.0.1:34801")
-		rm.GetReplica("127.0.0.1:34802")
-		rm.GetReplica("127.0.0.1:34803")
-		assert.Equal(t, len(rm.replicas), 3)
-
-		rm.RemoveUnused(map[string]bool{"127.0.0.1:34802": true})
-		assert.Equal(t, len(rm.replicas), 1)
-	}
+	rm.Close()
 }

--- a/session/session.go
+++ b/session/session.go
@@ -269,10 +269,6 @@ func (n *nodeSession) loopForResponse() error {
 // Invoke a rpc call.
 // The call will be cancelled if any io error encountered.
 func (n *nodeSession) callWithGpid(ctx context.Context, gpid *base.Gpid, args rpcRequestArgs, name string) (result rpcResponseResult, err error) {
-	if cstate := n.ConnState(); cstate != rpc.ConnStateReady {
-		return nil, fmt.Errorf("failed to send request to this node [%s, %s, state: %s]", n.ntype, n.addr, cstate)
-	}
-
 	rcall := &rpcCall{}
 	rcall.args = args
 	rcall.name = name


### PR DESCRIPTION
…ector.Close.

1. Closing table shouldn't close the connections.
    We add an unit test for this (TestPegasusTableConnector_Close).
2. Connection also shouldn't be closed when we find a configuration doesn't contains the replica sever,
    which may still being used by other table. So we revert pr#3.