### PR TITLE
Update configuration only when it's indeed necessary.

### DIFF
--- a/pegasus/client_test.go
+++ b/pegasus/client_test.go
@@ -7,7 +7,6 @@ package pegasus
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -134,7 +133,7 @@ func TestPegasusClient_SequentialOperations(t *testing.T) {
 	client := NewClient(cfg)
 	defer client.Close()
 
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < 5000; i++ {
 		ctx, _ := context.WithTimeout(context.Background(), time.Second*3)
 		hashKey := []byte(fmt.Sprintf("h%d", i))
 		sortKey := []byte(fmt.Sprintf("s%d", i))
@@ -147,8 +146,8 @@ func TestPegasusClient_SequentialOperations(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, actual, value)
 
-		//err = client.Del(ctx, "temp", hashKey, sortKey)
-		//assert.Nil(t, err)
+		err = client.Del(ctx, "temp", hashKey, sortKey)
+		assert.Nil(t, err)
 	}
 }
 
@@ -195,10 +194,6 @@ func TestPegasusClient_ConcurrentSetAndDel(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 1000; i++ {
 		wg.Add(1)
-
-		// sleep from 50ms to 150ms
-		randTime := time.Duration((rand.Intn(3) + 1) * 50)
-		time.Sleep(randTime * time.Millisecond)
 
 		id := i
 		go func() {

--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 	"sync"
 	"time"
@@ -50,11 +49,8 @@ type pegasusTableConnector struct {
 	parts     []*replicaNode
 	mu        sync.RWMutex
 
-	confUpdateCh            chan bool
-	lastConfUpdateTime      time.Time
-	randomConfUpdateTimeout time.Duration
-
-	tom tomb.Tomb
+	confUpdateCh chan bool
+	tom          tomb.Tomb
 }
 
 type replicaNode struct {
@@ -84,12 +80,6 @@ func connectTable(ctx context.Context, tableName string, meta *session.MetaManag
 // Update configuration of this table.
 func (p *pegasusTableConnector) updateConf(ctx context.Context) error {
 	resp, err := p.meta.QueryConfig(ctx, p.tableName)
-	defer func() {
-		p.lastConfUpdateTime = time.Now()
-
-		// randomly pick from 30s to 40s to protect meta server from heavy workload.
-		p.randomConfUpdateTimeout = time.Duration(rand.Intn(10)+30) * time.Second
-	}()
 	if err == nil {
 		err = p.handleQueryConfigResp(resp)
 	}
@@ -333,11 +323,24 @@ func (p *pegasusTableConnector) Close() error {
 
 func (p *pegasusTableConnector) handleError(err error, gpid *base.Gpid, replica *session.ReplicaSession) error {
 	if err != nil {
-		// when err != nil, it means the network connection between client and replicas
-		// may be illed, hence we need to check if there's newer configuration.
+		confUpdate := false
 
-		// trigger configuration update
-		p.tryConfUpdate()
+		switch err {
+		case base.ERR_TIMEOUT:
+		case context.DeadlineExceeded:
+			// timeout will not trigger a configuration update
+
+		case base.ERR_NOT_ENOUGH_MEMBER:
+		case base.ERR_CAPACITY_EXCEEDED:
+
+		default:
+			confUpdate = true
+		}
+
+		if confUpdate {
+			// we need to check if there's newer configuration.
+			p.tryConfUpdate()
+		}
 
 		// add gpid and remote address to error
 		perr := wrapError(err, 0).(*PError)
@@ -347,6 +350,7 @@ func (p *pegasusTableConnector) handleError(err error, gpid *base.Gpid, replica 
 	return nil
 }
 
+/// Don't bother if there's ongoing attempt.
 func (p *pegasusTableConnector) tryConfUpdate() {
 	select {
 	case p.confUpdateCh <- true:
@@ -354,15 +358,6 @@ func (p *pegasusTableConnector) tryConfUpdate() {
 	}
 }
 
-// For each table there's a background worker pulling down the latest
-// version of configuration from meta server automatically.
-// The configuration update strategy can be stated as follow:
-//
-//  - When a table operation encountered error, it will trigger a
-//    new round of self update if there's no one in progress.
-//  - The interval of two subsequent config updates should be larger
-//	  than `randomConfUpdateTimeout`.
-//
 func (p *pegasusTableConnector) loopForAutoUpdate() error {
 	for {
 		select {
@@ -383,10 +378,6 @@ func (p *pegasusTableConnector) loopForAutoUpdate() error {
 }
 
 func (p *pegasusTableConnector) selfUpdate() bool {
-	if time.Now().Sub(p.lastConfUpdateTime) < p.randomConfUpdateTimeout {
-		return false
-	}
-
 	// ignore the returned error
 	ctx, _ := context.WithTimeout(context.Background(), time.Second*10)
 	if err := p.updateConf(ctx); err != nil {

--- a/rpc/rpc_conn.go
+++ b/rpc/rpc_conn.go
@@ -184,7 +184,7 @@ func (rc *RpcConn) Read(size int) (bytes []byte, err error) {
 		return bytes, err
 	}()
 
-	if err != nil && !IsRetryableError(err) {
+	if err != nil && !IsNetworkTimeoutErr(err) {
 		rc.setState(ConnStateTransientFailure)
 	}
 	return bytes, err

--- a/rpc/rpc_conn_test.go
+++ b/rpc/rpc_conn_test.go
@@ -127,10 +127,10 @@ func TestRpcConn_WriteAndRead(t *testing.T) {
 	assert.Equal(t, data, actual)
 }
 
-func Test_IsRetryableError(t *testing.T) {
+func Test_IsNetworkTimeoutErr(t *testing.T) {
 	// timeout error but not a network error
-	assert.False(t, IsRetryableError(context.DeadlineExceeded))
+	assert.False(t, IsNetworkTimeoutErr(context.DeadlineExceeded))
 
 	err := NewRpcConn(&tomb.Tomb{}, "www.baidu.com:12321").TryConnect()
-	assert.True(t, IsRetryableError(err))
+	assert.True(t, IsNetworkTimeoutErr(err))
 }

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -9,7 +9,7 @@ import (
 )
 
 // err requires to be non-nil
-func IsRetryableError(err error) bool {
+func IsNetworkTimeoutErr(err error) bool {
 	// if it's a network timeout error
 	opErr, ok := err.(*net.OpError)
 	if ok {

--- a/session/session.go
+++ b/session/session.go
@@ -209,7 +209,7 @@ func (n *nodeSession) loopForRequest() error {
 				n.notifyCallerAndDrop(item)
 
 				// don give up if there's still hope
-				if !rpc.IsRetryableError(err) {
+				if !rpc.IsNetworkTimeoutErr(err) {
 					return err
 				}
 			}
@@ -231,7 +231,7 @@ func (n *nodeSession) loopForResponse() error {
 
 		call, err := n.readResponse()
 		if err != nil {
-			if rpc.IsRetryableError(err) {
+			if rpc.IsNetworkTimeoutErr(err) {
 				select {
 				case <-time.After(time.Second):
 					continue


### PR DESCRIPTION
We specified the types of error that are not necessary for fetching routing table:

- ERR_TIMEOUT
- context.DeadlineExceeded
- ERR_NOT_ENOUGH_MEMBER
- ERR_CAPACITY_EXCEEDED
