### PR TITLE
*: improve rpc throughput && bug fixes

### DIFF
--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -94,7 +94,7 @@ func (p *pegasusTableConnector) handleQueryConfigResp(resp *replication.QueryCfg
 		return errors.New(resp.Err.Errno)
 	}
 	if resp.PartitionCount == 0 || len(resp.Partitions) != int(resp.PartitionCount) {
-		return fmt.Errorf("invalid configuration: response [%v]", resp)
+		return fmt.Errorf("invalid table configuration: response [%v]", resp)
 	}
 
 	p.mu.Lock()
@@ -167,6 +167,9 @@ func (p *pegasusTableConnector) Get(ctx context.Context, hashKey []byte, sortKey
 		gpid, part := p.getPartition(hashKey)
 
 		resp, err := part.Get(ctx, gpid, key)
+		if err == nil {
+			err = base.NewDsnErrFromInt(resp.Error)
+		}
 		if err = p.handleReplicaError(err, gpid, part); err != nil {
 			return nil, err
 		} else {

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -72,16 +72,16 @@ func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {
 	assert.Nil(t, err)
 	ptb, _ := tb.(*pegasusTableConnector)
 
-	err = ptb.handleError(nil, nil, nil)
+	err = ptb.handleReplicaError(nil, nil, nil)
 	assert.Nil(t, err)
 
-	ptb.handleError(errors.New("not nil"), nil, nil)
+	ptb.handleReplicaError(errors.New("not nil"), nil, nil)
 	<-ptb.confUpdateCh
 
-	ptb.handleError(base.ERR_OBJECT_NOT_FOUND, nil, nil)
+	ptb.handleReplicaError(base.ERR_OBJECT_NOT_FOUND, nil, nil)
 	<-ptb.confUpdateCh
 
-	ptb.handleError(base.ERR_INVALID_STATE, nil, nil)
+	ptb.handleReplicaError(base.ERR_INVALID_STATE, nil, nil)
 	<-ptb.confUpdateCh
 
 	{ // Ensure: The following errors should not trigger configuration update
@@ -89,7 +89,7 @@ func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {
 
 		for _, err := range errorTypes {
 			channelEmpty := false
-			ptb.handleError(err, nil, nil)
+			ptb.handleReplicaError(err, nil, nil)
 			select {
 			case <-ptb.confUpdateCh:
 			default:

--- a/rpc/rpc_conn.go
+++ b/rpc/rpc_conn.go
@@ -60,8 +60,6 @@ func (s ConnState) String() string {
 
 var ErrConnectionNotReady = errors.New("connection is not ready")
 
-type DialerFunc func(ctx context.Context, address string) (net.Conn, error)
-
 // RpcConn maintains a network connection to a particular endpoint.
 type RpcConn struct {
 	Endpoint string

--- a/rpc/stream_in.go
+++ b/rpc/stream_in.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	// In our experiment(go-ycsb, 100w insertions, 100 goroutines, 1kb record size),
+	// In our experiment(go-ycsb, 100w insertions, 100 goroutines, 100 bytes record size),
 	// rpc performance can significantly be improved by increasing read buffer.
 	// As we continue to double the buffer size from 256KB to 512KB, the throughput
 	// as well as average latency stop gaining improvement.
+	// See Issue#4 for more detail.
 	//
 	// read buffer 64kb
 	// INSERT - Count: 192010, Avg(us): 3482, Min(us): 386, Max(us): 42951, 95th(us): 8000, 99th(us): 14000
@@ -32,13 +33,13 @@ const (
 	// INSERT - Count: 999999, Avg(us): 3140, Min(us): 322, Max(us): 57728, 95th(us): 7000, 99th(us): 15000
 	// Run finished, takes 43.703584059s
 	//
-	// response buffer 256kb
+	// read buffer 256kb
 	// INSERT - Count: 366927, Avg(us): 2511, Min(us): 347, Max(us): 50030, 95th(us): 7000, 99th(us): 15000
 	// INSERT - Count: 701266, Avg(us): 2649, Min(us): 344, Max(us): 73976, 95th(us): 8000, 99th(us): 17000
 	// INSERT - Count: 1000000, Avg(us): 2615, Min(us): 340, Max(us): 73976, 95th(us): 8000, 99th(us): 17000
 	// Run finished, takes 28.381599693s
 	//
-	// response buffer 512kb
+	// read buffer 512kb
 	// INSERT - Count: 366486, Avg(us): 2596, Min(us): 332, Max(us): 83957, 95th(us): 8000, 99th(us): 17000
 	// INSERT - Count: 725917, Avg(us): 2624, Min(us): 320, Max(us): 83957, 95th(us): 8000, 99th(us): 18000
 	// INSERT - Count: 999999, Avg(us): 2634, Min(us): 320, Max(us): 95898, 95th(us): 8000, 99th(us): 18000

--- a/rpc/stream_in.go
+++ b/rpc/stream_in.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// In our experiment(go-ycsb, 100w insertions, 100 goroutines, 1kb record size),
-	// rpc performance can significantly improve while read buffer increases.
+	// rpc performance can significantly be improved by increasing read buffer.
 	// As we continue to double the buffer size from 256KB to 512KB, the throughput
 	// as well as average latency stop gaining improvement.
 	//
@@ -32,13 +32,13 @@ const (
 	// INSERT - Count: 999999, Avg(us): 3140, Min(us): 322, Max(us): 57728, 95th(us): 7000, 99th(us): 15000
 	// Run finished, takes 43.703584059s
 	//
-	// response buffer 256kb, no request channel
+	// response buffer 256kb
 	// INSERT - Count: 366927, Avg(us): 2511, Min(us): 347, Max(us): 50030, 95th(us): 7000, 99th(us): 15000
 	// INSERT - Count: 701266, Avg(us): 2649, Min(us): 344, Max(us): 73976, 95th(us): 8000, 99th(us): 17000
 	// INSERT - Count: 1000000, Avg(us): 2615, Min(us): 340, Max(us): 73976, 95th(us): 8000, 99th(us): 17000
 	// Run finished, takes 28.381599693s
 	//
-	// response buffer 512kb, no request channel
+	// response buffer 512kb
 	// INSERT - Count: 366486, Avg(us): 2596, Min(us): 332, Max(us): 83957, 95th(us): 8000, 99th(us): 17000
 	// INSERT - Count: 725917, Avg(us): 2624, Min(us): 320, Max(us): 83957, 95th(us): 8000, 99th(us): 18000
 	// INSERT - Count: 999999, Avg(us): 2634, Min(us): 320, Max(us): 95898, 95th(us): 8000, 99th(us): 18000

--- a/rpc/stream_in.go
+++ b/rpc/stream_in.go
@@ -5,22 +5,61 @@
 package rpc
 
 import (
+	"bufio"
 	"io"
+)
+
+const (
+	// In our experiment(go-ycsb, 100w insertions, 100 goroutines, 1kb record size),
+	// rpc performance can significantly improve while read buffer increases.
+	// As we continue to double the buffer size from 256KB to 512KB, the throughput
+	// as well as average latency stop gaining improvement.
+	//
+	// read buffer 64kb
+	// INSERT - Count: 192010, Avg(us): 3482, Min(us): 386, Max(us): 42951, 95th(us): 8000, 99th(us): 14000
+	// INSERT - Count: 387387, Avg(us): 3447, Min(us): 356, Max(us): 45644, 95th(us): 8000, 99th(us): 14000
+	// INSERT - Count: 584503, Avg(us): 3412, Min(us): 356, Max(us): 45644, 95th(us): 7000, 99th(us): 13000
+	// INSERT - Count: 774928, Avg(us): 3438, Min(us): 356, Max(us): 45644, 95th(us): 7000, 99th(us): 13000
+	// INSERT - Count: 965434, Avg(us): 3451, Min(us): 338, Max(us): 77322, 95th(us): 7000, 99th(us): 13000
+	// INSERT - Count: 1000000, Avg(us): 3443, Min(us): 338, Max(us): 77322, 95th(us): 7000, 99th(us): 13000
+	// Run finished, takes 51.837521852s
+	//
+	// read buffer 128kb
+	// INSERT - Count: 225254, Avg(us): 3139, Min(us): 357, Max(us): 36666, 95th(us): 7000, 99th(us): 14000
+	// INSERT - Count: 458059, Avg(us): 3110, Min(us): 357, Max(us): 42223, 95th(us): 7000, 99th(us): 14000
+	// INSERT - Count: 683384, Avg(us): 3135, Min(us): 340, Max(us): 42223, 95th(us): 7000, 99th(us): 14000
+	// INSERT - Count: 915600, Avg(us): 3157, Min(us): 322, Max(us): 57728, 95th(us): 7000, 99th(us): 15000
+	// INSERT - Count: 999999, Avg(us): 3140, Min(us): 322, Max(us): 57728, 95th(us): 7000, 99th(us): 15000
+	// Run finished, takes 43.703584059s
+	//
+	// response buffer 256kb, no request channel
+	// INSERT - Count: 366927, Avg(us): 2511, Min(us): 347, Max(us): 50030, 95th(us): 7000, 99th(us): 15000
+	// INSERT - Count: 701266, Avg(us): 2649, Min(us): 344, Max(us): 73976, 95th(us): 8000, 99th(us): 17000
+	// INSERT - Count: 1000000, Avg(us): 2615, Min(us): 340, Max(us): 73976, 95th(us): 8000, 99th(us): 17000
+	// Run finished, takes 28.381599693s
+	//
+	// response buffer 512kb, no request channel
+	// INSERT - Count: 366486, Avg(us): 2596, Min(us): 332, Max(us): 83957, 95th(us): 8000, 99th(us): 17000
+	// INSERT - Count: 725917, Avg(us): 2624, Min(us): 320, Max(us): 83957, 95th(us): 8000, 99th(us): 18000
+	// INSERT - Count: 999999, Avg(us): 2634, Min(us): 320, Max(us): 95898, 95th(us): 8000, 99th(us): 18000
+	// Run finished, takes 27.91239882s
+
+	readStreamBufferSize = 1024 * 256
 )
 
 // low-level rpc reader.
 type ReadStream struct {
-	reader io.Reader
+	bufReader *bufio.Reader
 }
 
 func (r *ReadStream) Next(toRead int) ([]byte, error) {
 	buf := make([]byte, toRead)
 	var total = 0
 
-	readSz, err := r.reader.Read(buf)
+	readSz, err := r.bufReader.Read(buf)
 	total += readSz
 	for total < toRead && err == nil {
-		readSz, err = r.reader.Read(buf[total:])
+		readSz, err = r.bufReader.Read(buf[total:])
 		total += readSz
 	}
 
@@ -32,6 +71,6 @@ func (r *ReadStream) Next(toRead int) ([]byte, error) {
 
 func NewReadStream(reader io.Reader) *ReadStream {
 	return &ReadStream{
-		reader: reader,
+		bufReader: bufio.NewReaderSize(reader, readStreamBufferSize),
 	}
 }

--- a/session/codec_test.go
+++ b/session/codec_test.go
@@ -40,7 +40,7 @@ func TestCodec_Marshal(t *testing.T) {
 		seqId: 1,
 	}
 
-	actual, _ := PegasusCodec{}.Marshal(r)
+	actual, _ := new(PegasusCodec).Marshal(r)
 	assert.Equal(t, expected, actual)
 }
 
@@ -50,6 +50,7 @@ func TestCodec_UnmarshalErrorCode(t *testing.T) {
 	}
 
 	r := &rpcCall{}
-	err := PegasusCodec{}.Unmarshal(recvBytes, r)
+
+	err := new(PegasusCodec).Unmarshal(recvBytes, r)
 	assert.NotNil(t, err)
 }

--- a/session/doc.go
+++ b/session/doc.go
@@ -1,9 +1,0 @@
-package session
-
-//
-// Here we document the strategy of self update.
-// Self update is a mechanism we used in to keep
-//
-// TODO:
-//  - Automatically remove the connection that is long-time not used, or
-//    dialing for

--- a/session/meta_session.go
+++ b/session/meta_session.go
@@ -47,10 +47,10 @@ func (ms *metaSession) queryConfig(ctx context.Context, tableName string) (*repl
 	arg.Query.AppName = tableName
 	arg.Query.PartitionIndices = []int32{}
 
-	ms.logger.Printf("querying configuration of table(%s) from [%s, %s]\n", tableName, ms.addr, ms.ntype)
+	ms.logger.Printf("querying configuration of table(%s) from [%s, %s]", tableName, ms.addr, ms.ntype)
 	result, err := ms.call(ctx, arg, "RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX")
 	if err != nil {
-		ms.logger.Printf("failed to query configuration from meta %s: %s\n", ms.addr, err)
+		ms.logger.Printf("failed to query configuration from meta %s: %s", ms.addr, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
- codec: initialize logger when creating PegasusCodec to avoid read lock in logging.
- codec: read message begin after error code is read, even when it's not ok
- table_connector: don't add gpid & replica to error when err is nil
- session: marshall rpc by caller to improve throughput
- rpc: increase read buffer size to improve throughput (#4)