### PR TITLE
pegasus2/session: fix bug when receiving a stale response

### DIFF
--- a/pegasus2/client.go
+++ b/pegasus2/client.go
@@ -26,7 +26,8 @@ func NewClient(cfg pegasus.Config) *Client {
 
 func (p *Client) OpenTable(ctx context.Context, tableName string) (pegasus.TableConnector, error) {
 	tb, err := func() (pegasus.TableConnector, error) {
-		// each table instance holds set of replica sessions.
+		// Each table holds an independent set of replica sessions.
+		// The meta sessions are shared by tables created from the same client.
 		replicaMgr := session.NewReplicaManager(newNodeSession)
 		return pegasus.ConnectTable(ctx, tableName, p.metaMgr, replicaMgr)
 	}()

--- a/pegasus2/session_test.go
+++ b/pegasus2/session_test.go
@@ -1,1 +1,84 @@
 package pegasus2
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"encoding/binary"
+	"github.com/XiaoMi/pegasus-go-client/idl/base"
+	"github.com/XiaoMi/pegasus-go-client/idl/rrdb"
+	"github.com/XiaoMi/pegasus-go-client/pegasus"
+	"github.com/XiaoMi/pegasus-go-client/session"
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeSession_SendTimeout(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*1)
+
+	client := NewClient(pegasus.Config{
+		MetaServers: []string{"0.0.0.0:34601", "0.0.0.0:34602", "0.0.0.0:34603"},
+	})
+	tb, err := client.OpenTable(context.Background(), "temp")
+	assert.Nil(t, err)
+	defer tb.Close()
+	defer client.Close()
+
+	// ensure deadline has expired.
+	time.Sleep(time.Second)
+
+	// send must timeout
+	err = tb.Set(ctx, []byte("h1"), []byte("s1"), []byte("v1"))
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "send rpc timeout"))
+}
+
+// test the case: request is seqId:3, but response is seqId:1
+func TestNodeSession_ReadStaleResponse(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	// start echo server first
+	n := newNodeSession("0.0.0.0:8800", session.NodeTypeMeta).(*nodeSession)
+	defer n.Close()
+
+	var expected []byte
+	var actual []byte
+
+	mockCodec := &session.MockCodec{}
+	mockCodec.MockMarshal(func(v interface{}) ([]byte, error) {
+		expected, _ = new(session.PegasusCodec).Marshal(v)
+		buf := make([]byte, len(expected)+4)
+
+		// prefixed with length
+		binary.BigEndian.PutUint32(buf, uint32(len(buf)))
+		copy(buf[4:], expected)
+
+		return buf, nil
+	})
+
+	mockCodec.MockUnMarshal(func(data []byte, v interface{}) error {
+		actual = data
+		r, _ := v.(*session.PegasusRpcCall)
+		r.SeqId = 1
+		r.Name = "RPC_RRDB_RRDB_GET_ACK"
+		r.Result = &rrdb.RrdbGetResult{
+			Success: rrdb.NewReadResponse(),
+		}
+		return nil
+	})
+
+	n.codec = mockCodec
+
+	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*1000)
+
+	n.seqId = 2
+	args := &rrdb.RrdbGetArgs{Key: &base.Blob{Data: []byte("a")}}
+	_, err := n.CallWithGpid(ctx, &base.Gpid{}, args, "RPC_RRDB_RRDB_GET")
+
+	// ensure rpc timeout due to stale response
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
This bug happens when a PUT rpc is timeout, the later GET rpc will trigger a type mismatch, where
the client sends a GET request, but the response is of PUT_ACK type. And since the type is mismatched, the following codes will raise a nil pointer panic.

```go
func (rs *ReplicaSession) Get(ctx context.Context, gpid *base.Gpid, key *base.Blob) (*rrdb.ReadResponse, error) {
...
	ret, _ := result.(*rrdb.RrdbGetResult) // the response is actually a RrdbPutResult, so ret=nil
	return ret.GetSuccess(), nil
}
```

```
2018/07/02 13:33:13 querying configuration of table(temp) from [127.0.0.1:34601(meta)]
2018/07/02 13:33:13 pegasus-go-client SET failed: read tcp 10.231.58.215:58556->10.231.58.215:34803: i/o timeout [Gpid({Appid:1 PartitionIndex:5}), [10.231.58.215:34803(replica)]]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6a0a5c]
```

This is because when a response is unable to be read in given timeout, it will be read by the later rpc.
Therefore we must handle stale response.

After this PR:
```
2018/07/02 16:19:41 pegasus-go-client SET failed: read tcp 10.231.58.215:38642->10.231.58.215:34801: i/o timeout [Gpid({Appid:1 PartitionIndex:6}), [10.231.58.215:34801(replica)]]
2018/07/02 16:19:41 querying configuration of table(temp) from [127.0.0.1:34601(meta)]
2018/07/02 16:19:42 ignore stale response (seqId: 49044, current seqId: 49045) from [10.231.58.215:34801(replica)]: RPC_RRDB_RRDB_PUT_ACK
```
Nil pointer panic is gone.