### PR TITLE
pegasus: suppress warnings of staticcheck, govet, golint

### DIFF
--- a/pegasus/check_and_set.go
+++ b/pegasus/check_and_set.go
@@ -6,8 +6,10 @@ package pegasus
 
 import "github.com/XiaoMi/pegasus-go-client/idl/rrdb"
 
+// CheckType defines the types of value checking in a CAS.
 type CheckType int
 
+// The value checking types
 const (
 	CheckTypeNoCheck = CheckType(rrdb.CasCheckType_CT_NO_CHECK)
 
@@ -37,6 +39,7 @@ const (
 	CheckTypeIntGreater        = CheckType(rrdb.CasCheckType_CT_VALUE_BYTES_GREATER)        // int compare: value > operand
 )
 
+// CheckAndSetResult is the result of a CAS.
 type CheckAndSetResult struct {
 	// true if set value succeed.
 	SetSucceed bool
@@ -51,6 +54,7 @@ type CheckAndSetResult struct {
 	CheckValueReturned bool
 }
 
+// CheckAndSetOptions is the options of a CAS.
 type CheckAndSetOptions struct {
 	SetValueTTLSeconds int  // time to live in seconds of the set value, 0 means no ttl.
 	ReturnCheckValue   bool // if return the check value in results.

--- a/pegasus/client.go
+++ b/pegasus/client.go
@@ -58,9 +58,10 @@ func (p *pegasusClient) Close() error {
 		}
 	}
 
-	err := p.metaMgr.Close()
-	err = p.replicaMgr.Close()
-	return err
+	if err := p.metaMgr.Close(); err != nil {
+		pegalog.GetLogger().Fatalln("pegasus-go-client: unable to close metaMgr: ", err)
+	}
+	return p.replicaMgr.Close()
 }
 
 func (p *pegasusClient) OpenTable(ctx context.Context, tableName string) (TableConnector, error) {

--- a/pegasus/client.go
+++ b/pegasus/client.go
@@ -12,8 +12,7 @@ import (
 	"github.com/XiaoMi/pegasus-go-client/session"
 )
 
-// Client is the main interface to pegasus.
-// Each client is bound to a pegasus cluster specified by `Config`.
+// Client manages the client sessions to the pegasus cluster specified by `Config`.
 // In order to reuse the previous connections, it's recommended to use one singleton
 // client in your program. The operations upon a client instance are thread-safe.
 type Client interface {
@@ -34,6 +33,7 @@ type pegasusClient struct {
 	replicaMgr *session.ReplicaManager
 }
 
+// NewClient creates a new instance of pegasus client.
 func NewClient(cfg Config) Client {
 	if len(cfg.MetaServers) == 0 {
 		pegalog.GetLogger().Fatalln("pegasus-go-client: meta sever list should not be empty")

--- a/pegasus/client.go
+++ b/pegasus/client.go
@@ -36,7 +36,7 @@ type pegasusClient struct {
 // NewClient creates a new instance of pegasus client.
 func NewClient(cfg Config) Client {
 	if len(cfg.MetaServers) == 0 {
-		pegalog.GetLogger().Fatalln("pegasus-go-client: meta sever list should not be empty")
+		pegalog.GetLogger().Fatalln("pegasus-go-client: meta server list should not be empty")
 		return nil
 	}
 

--- a/pegasus/client_test.go
+++ b/pegasus/client_test.go
@@ -56,7 +56,8 @@ func TestPegasusClient_OpenTableTimeout(t *testing.T) {
 
 	client := NewClient(cfg)
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*2)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
 	tb, err := client.OpenTable(ctx, "temp")
 	assert.Equal(t, ctx.Err(), context.DeadlineExceeded)
 	assert.Nil(t, tb)
@@ -83,7 +84,8 @@ func TestPegasusClient_ConcurrentOpenSameTable(t *testing.T) {
 	for i := 0; i < openTableQueries; i++ {
 		wg.Add(1)
 		go func() {
-			ctx, _ := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
 			tb, err := client.OpenTable(ctx, "temp")
 			assert.Nil(t, err)
 			tblist = append(tblist, tb)
@@ -115,7 +117,8 @@ func TestPegasusClient_ConcurrentMetaQueries(t *testing.T) {
 
 		id := i
 		go func() {
-			ctx, _ := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
 			_, err := client.OpenTable(ctx, "table_not_exist"+fmt.Sprint(id))
 			assert.NotNil(t, err)
 			wg.Done()

--- a/pegasus/config.go
+++ b/pegasus/config.go
@@ -4,6 +4,7 @@
 
 package pegasus
 
+// Config is the configuration of pegasus client.
 type Config struct {
 	MetaServers []string `json:"meta_servers"`
 }

--- a/pegasus/error.go
+++ b/pegasus/error.go
@@ -8,16 +8,19 @@ import (
 	"fmt"
 )
 
+// PError is the return error type of all interfaces of pegasus client.
 type PError struct {
 	// Err is the error that occurred during the operation.
 	Err error
 
-	// Op is the operation that caused this error
+	// The failed operation
 	Op OpType
 }
 
+// OpType is the type of operation that led to PError.
 type OpType int
 
+// Operation types
 const (
 	OpQueryConfig OpType = iota
 	OpGet

--- a/pegasus/filter.go
+++ b/pegasus/filter.go
@@ -6,8 +6,10 @@ package pegasus
 
 import "github.com/XiaoMi/pegasus-go-client/idl/rrdb"
 
+// FilterType defines the type of key filtering.
 type FilterType int
 
+// Filter types
 const (
 	FilterTypeNoFilter      = FilterType(rrdb.FilterType_FT_NO_FILTER)
 	FilterTypeMatchAnywhere = FilterType(rrdb.FilterType_FT_MATCH_ANYWHERE)
@@ -15,6 +17,7 @@ const (
 	FilterTypeMatchPostfix  = FilterType(rrdb.FilterType_FT_MATCH_POSTFIX)
 )
 
+// Filter is used to filter based on the key.
 type Filter struct {
 	Type    FilterType
 	Pattern []byte

--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -60,24 +60,28 @@ var DefaultMultiGetOptions = &MultiGetOptions{
 type TableConnector interface {
 	// Get retrieves the entry for `hashKey` + `sortKey`.
 	// Returns nil if no entry matches.
-	// `hashKey` : CAN'T be nil.
+	// `hashKey` : CAN'T be nil or empty.
+	// `sortKey` : CAN'T be nil but CAN be empty.
 	Get(ctx context.Context, hashKey []byte, sortKey []byte) ([]byte, error)
 
 	// Set the entry for `hashKey` + `sortKey` to `value`.
 	// If Set is called or `ttl` == 0, no data expiration is specified.
-	// `hashKey` / `value` : CAN'T be nil.
+	// `hashKey` : CAN'T be nil or empty.
+	// `sortKey` / `value` : CAN'T be nil but CAN be empty.
 	Set(ctx context.Context, hashKey []byte, sortKey []byte, value []byte) error
 	SetTTL(ctx context.Context, hashKey []byte, sortKey []byte, value []byte, ttl time.Duration) error
 
 	// Delete the entry for `hashKey` + `sortKey`.
-	// `hashKey` : CAN'T be nil.
+	// `hashKey` : CAN'T be nil or empty.
+	// `sortKey` : CAN'T be nil but CAN be empty.
 	Del(ctx context.Context, hashKey []byte, sortKey []byte) error
 
 	// MultiGet/MultiGetOpt retrieves the multiple entries for `hashKey` + `sortKeys[i]` atomically in one operation.
 	// MultiGet is identical to MultiGetOpt except that the former uses DefaultMultiGetOptions as `options`.
 	//
 	// If `sortKeys` are given empty or nil, all entries under `hashKey` will be retrieved.
-	// `hashKey` : CAN'T be nil.
+	// `hashKey / sortKeys` : CAN'T be nil or empty.
+	// `sortKeys[i]` : CAN'T be nil but CAN be empty.
 	//
 	// The returned key-value pairs are sorted by sort key in ascending order.
 	// Returns nil if no entries match.
@@ -101,27 +105,29 @@ type TableConnector interface {
 	MultiGetRangeOpt(ctx context.Context, hashKey []byte, startSortKey []byte, stopSortKey []byte, options *MultiGetOptions) ([]*KeyValue, bool, error)
 
 	// MultiSet sets the multiple entries for `hashKey` + `sortKeys[i]` atomically in one operation.
-	// `hashKey` / `sortKeys` / `values` / `values[i]`: CAN'T be nil.
+	// `hashKey` / `sortKeys` / `values` : CAN'T be nil or empty.
+	// `values[i]` : CAN'T be nil but CAN be empty.
 	MultiSet(ctx context.Context, hashKey []byte, sortKeys [][]byte, values [][]byte) error
 	MultiSetOpt(ctx context.Context, hashKey []byte, sortKeys [][]byte, values [][]byte, ttl time.Duration) error
 
 	// MultiDel deletes the multiple entries under `hashKey` all in one operation.
-	// `hashKey` / `sortKeys`: CAN'T be nil.
+	// `hashKey` / `sortKeys` : CAN'T be nil or empty.
 	// Returns sort key of deleted entries.
 	MultiDel(ctx context.Context, hashKey []byte, sortKeys [][]byte) error
 
 	// Returns ttl(time-to-live) in seconds: -1 if ttl is not set; -2 if entry doesn't exist.
-	// `hashKey`: CAN'T be nil.
+	// `hashKey` : CAN'T be nil or empty.
+	// `sortKey` : CAN'T be nil but CAN be empty.
 	TTL(ctx context.Context, hashKey []byte, sortKey []byte) (int, error)
 
 	// Check value existence for the entry for `hashKey` + `sortKey`.
-	// `hashKey`: CAN'T be nil.
+	// `hashKey`: CAN'T be nil or empty.
 	Exist(ctx context.Context, hashKey []byte, sortKey []byte) (bool, error)
 
 	// Get Scanner for {startSortKey, stopSortKey} within hashKey.
 	// startSortKey: nil or len(startSortKey) == 0 means start from begin.
 	// stopSortKey: nil or len(stopSortKey) == 0 means stop to end.
-	// `hashKey`: CAN'T be nil.
+	// `hashKey`: CAN'T be nil or empty.
 	GetScanner(ctx context.Context, hashKey []byte, startSortKey []byte, stopSortKey []byte, options *ScannerOptions) (Scanner, error)
 
 	// Get Scanners for all data in pegasus, the count of scanners will
@@ -138,7 +144,7 @@ type TableConnector interface {
 		checkOperand []byte, setSortKey []byte, setValue []byte, options *CheckAndSetOptions) (*CheckAndSetResult, error)
 
 	// Returns the count of sortkeys under hashkey.
-	// `hashKey`: CAN'T be nil.
+	// `hashKey`: CAN'T be nil or empty.
 	SortKeyCount(ctx context.Context, hashKey []byte) (int64, error)
 
 	Close() error
@@ -231,25 +237,58 @@ func (p *pegasusTableConnector) handleQueryConfigResp(resp *replication.QueryCfg
 }
 
 func validateHashKey(hashKey []byte) error {
-	if len(hashKey) == 0 || hashKey == nil {
-		return fmt.Errorf("InvalidParameter: hash key must not be empty")
+	if hashKey == nil {
+		return fmt.Errorf("InvalidParameter: hashkey must not be nil")
+	}
+	if len(hashKey) == 0 {
+		return fmt.Errorf("InvalidParameter: hashkey must not be empty")
 	}
 	if len(hashKey) > math.MaxUint16 {
-		return fmt.Errorf("InvalidParameter: length of hash key (%d) must be less than %d", len(hashKey), math.MaxUint16)
+		return fmt.Errorf("InvalidParameter: length of hashkey (%d) must be less than %d", len(hashKey), math.MaxUint16)
 	}
 	return nil
 }
 
 func validateValue(value []byte) error {
-	if value == nil || len(value) == 0 {
-		return fmt.Errorf("InvalidParameter: value must not be empty")
+	if value == nil {
+		return fmt.Errorf("InvalidParameter: value must not be nil")
+	}
+	return nil
+}
+
+func validateValues(values [][]byte) error {
+	if values == nil {
+		return fmt.Errorf("InvalidParameter: values must not be nil")
+	}
+	if len(values) == 0 {
+		return fmt.Errorf("InvalidParameter: values must not be empty")
+	}
+	for i, value := range values {
+		if value == nil {
+			return fmt.Errorf("InvalidParameter: values[%d] must not be nil", i)
+		}
+	}
+	return nil
+}
+
+func validateSortKey(sortKey []byte) error {
+	if sortKey == nil {
+		return fmt.Errorf("InvalidParameter: sortkey must not be nil")
 	}
 	return nil
 }
 
 func validateSortKeys(sortKeys [][]byte) error {
-	if sortKeys == nil || len(sortKeys) == 0 {
+	if sortKeys == nil {
+		return fmt.Errorf("InvalidParameter: sortkeys must not be nil")
+	}
+	if len(sortKeys) == 0 {
 		return fmt.Errorf("InvalidParameter: sortkeys must not be empty")
+	}
+	for i, sortKey := range sortKeys {
+		if sortKey == nil {
+			return fmt.Errorf("InvalidParameter: sortkeys[%d] must not be nil", i)
+		}
 	}
 	return nil
 }
@@ -273,6 +312,9 @@ func WrapError(err error, op OpType) error {
 func (p *pegasusTableConnector) Get(ctx context.Context, hashKey []byte, sortKey []byte) ([]byte, error) {
 	b, err := func() ([]byte, error) {
 		if err := validateHashKey(hashKey); err != nil {
+			return nil, err
+		}
+		if err := validateSortKey(sortKey); err != nil {
 			return nil, err
 		}
 
@@ -299,6 +341,9 @@ func (p *pegasusTableConnector) Get(ctx context.Context, hashKey []byte, sortKey
 func (p *pegasusTableConnector) SetTTL(ctx context.Context, hashKey []byte, sortKey []byte, value []byte, ttl time.Duration) error {
 	err := func() error {
 		if err := validateHashKey(hashKey); err != nil {
+			return err
+		}
+		if err := validateSortKey(sortKey); err != nil {
 			return err
 		}
 		if err := validateValue(value); err != nil {
@@ -331,6 +376,9 @@ func (p *pegasusTableConnector) Del(ctx context.Context, hashKey []byte, sortKey
 		if err := validateHashKey(hashKey); err != nil {
 			return err
 		}
+		if err := validateSortKey(sortKey); err != nil {
+			return err
+		}
 
 		key := encodeHashKeySortKey(hashKey, sortKey)
 		gpid, part := p.getPartition(hashKey)
@@ -359,8 +407,8 @@ func (p *pegasusTableConnector) MultiGetOpt(ctx context.Context, hashKey []byte,
 		if err := validateHashKey(hashKey); err != nil {
 			return nil, false, err
 		}
-		if sortKeys == nil {
-			sortKeys = make([][]byte, 0)
+		if err := validateSortKeys(sortKeys); err != nil {
+			return nil, false, err
 		}
 
 		request := rrdb.NewMultiGetRequest()
@@ -450,13 +498,8 @@ func (p *pegasusTableConnector) MultiSetOpt(ctx context.Context, hashKey []byte,
 		if err := validateSortKeys(sortKeys); err != nil {
 			return err
 		}
-		if values == nil || len(values) == 0 {
-			return fmt.Errorf("InvalidParameter: values must not be empty")
-		}
-		for _, v := range values {
-			if err := validateValue(v); err != nil {
-				return err
-			}
+		if err := validateValues(values); err != nil {
+			return err
 		}
 		if len(sortKeys) != len(values) {
 			return fmt.Errorf("InvalidParameter: unmatched key-value pairs: len(sortKeys)=%d len(values)=%d",
@@ -527,6 +570,9 @@ func (p *pegasusTableConnector) MultiDel(ctx context.Context, hashKey []byte, so
 
 func (p *pegasusTableConnector) doTTL(ctx context.Context, hashKey []byte, sortKey []byte) (int, error) {
 	if err := validateHashKey(hashKey); err != nil {
+		return 0, err
+	}
+	if err := validateSortKey(sortKey); err != nil {
 		return 0, err
 	}
 

--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -80,7 +80,7 @@ type TableConnector interface {
 	// MultiGet is identical to MultiGetOpt except that the former uses DefaultMultiGetOptions as `options`.
 	//
 	// If `sortKeys` are given empty or nil, all entries under `hashKey` will be retrieved.
-	// `hashKey / sortKeys` : CAN'T be nil or empty.
+	// `hashKey` : CAN'T be nil or empty.
 	// `sortKeys[i]` : CAN'T be nil but CAN be empty.
 	//
 	// The returned key-value pairs are sorted by sort key in ascending order.
@@ -106,13 +106,13 @@ type TableConnector interface {
 
 	// MultiSet sets the multiple entries for `hashKey` + `sortKeys[i]` atomically in one operation.
 	// `hashKey` / `sortKeys` / `values` : CAN'T be nil or empty.
-	// `values[i]` : CAN'T be nil but CAN be empty.
+	// `sortKeys[i]` / `values[i]` : CAN'T be nil but CAN be empty.
 	MultiSet(ctx context.Context, hashKey []byte, sortKeys [][]byte, values [][]byte) error
 	MultiSetOpt(ctx context.Context, hashKey []byte, sortKeys [][]byte, values [][]byte, ttl time.Duration) error
 
 	// MultiDel deletes the multiple entries under `hashKey` all in one operation.
 	// `hashKey` / `sortKeys` : CAN'T be nil or empty.
-	// Returns sort key of deleted entries.
+	// `sortKeys[i]` : CAN'T be nil but CAN be empty.
 	MultiDel(ctx context.Context, hashKey []byte, sortKeys [][]byte) error
 
 	// Returns ttl(time-to-live) in seconds: -1 if ttl is not set; -2 if entry doesn't exist.

--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -407,8 +407,11 @@ func (p *pegasusTableConnector) MultiGetOpt(ctx context.Context, hashKey []byte,
 		if err := validateHashKey(hashKey); err != nil {
 			return nil, false, err
 		}
-		if err := validateSortKeys(sortKeys); err != nil {
-			return nil, false, err
+		if sortKeys != nil && len(sortKeys) != 0 {
+			// sortKeys are nil-able, nil means fetching all entries.
+			if err := validateSortKeys(sortKeys); err != nil {
+				return nil, false, err
+			}
 		}
 
 		request := rrdb.NewMultiGetRequest()

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -5,6 +5,7 @@
 package pegasus
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"bytes"
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
 	"github.com/XiaoMi/pegasus-go-client/idl/replication"
 	"github.com/XiaoMi/pegasus-go-client/rpc"
@@ -206,9 +206,10 @@ func TestPegasusTableConnector_EmptyInput(t *testing.T) {
 	assert.Contains(t, err.Error(), "sortkeys must not be empty")
 
 	_, _, err = tb.MultiGet(context.Background(), []byte("h1"), nil)
-	assert.Contains(t, err.Error(), "sortkeys must not be nil")
+	assert.Nil(t, err)
+
 	_, _, err = tb.MultiGetOpt(context.Background(), []byte("h1"), [][]byte{}, &MultiGetOptions{})
-	assert.Contains(t, err.Error(), "sortkeys must not be empty")
+	assert.Nil(t, err)
 
 	// === empty sortkey === //
 

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -107,7 +107,6 @@ func TestPegasusTableConnector_SingleKeyOperations(t *testing.T) {
 	wg.Wait()
 }
 
-// ensure client will return InvalidArguments errors when input is empty.
 func TestPegasusTableConnector_EmptyInput(t *testing.T) {
 	cfg := Config{
 		MetaServers: []string{"0.0.0.0:34601", "0.0.0.0:34602", "0.0.0.0:34603"},
@@ -122,76 +121,113 @@ func TestPegasusTableConnector_EmptyInput(t *testing.T) {
 	// === empty hashkey === //
 
 	_, err = tb.TTL(context.Background(), nil, nil)
-	assert.NotNil(t, err)
-	_, err2 := tb.TTL(context.Background(), []byte{}, nil)
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	_, err = tb.TTL(context.Background(), []byte{}, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	_, err = tb.Exist(context.Background(), nil, nil)
-	assert.NotNil(t, err)
-	_, err2 = tb.Exist(context.Background(), []byte{}, nil)
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	_, err = tb.Exist(context.Background(), []byte{}, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	err = tb.SetTTL(context.Background(), nil, nil, nil, 0)
-	assert.NotNil(t, err)
-	err2 = tb.Set(context.Background(), []byte{}, nil, nil)
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	err = tb.Set(context.Background(), []byte{}, nil, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	_, err = tb.Get(context.Background(), nil, nil)
-	assert.NotNil(t, err)
-	_, err2 = tb.Get(context.Background(), []byte{}, nil)
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	_, err = tb.Get(context.Background(), []byte{}, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	_, _, err = tb.MultiGet(context.Background(), nil, nil)
-	assert.NotNil(t, err)
-	_, _, err2 = tb.MultiGetOpt(context.Background(), []byte{}, nil, &MultiGetOptions{})
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	_, _, err = tb.MultiGetOpt(context.Background(), []byte{}, nil, &MultiGetOptions{})
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	_, _, err = tb.MultiGetRange(context.Background(), nil, nil, nil)
-	assert.NotNil(t, err)
-	_, _, err2 = tb.MultiGetRangeOpt(context.Background(), []byte{}, nil, nil, &MultiGetOptions{})
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	_, _, err = tb.MultiGetRangeOpt(context.Background(), []byte{}, nil, nil, &MultiGetOptions{})
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	err = tb.MultiSet(context.Background(), nil, nil, nil)
-	assert.NotNil(t, err)
-	err2 = tb.MultiSetOpt(context.Background(), []byte{}, nil, nil, 0)
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	err = tb.MultiSetOpt(context.Background(), []byte{}, nil, nil, 0)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	err = tb.MultiDel(context.Background(), nil, nil)
-	assert.NotNil(t, err)
-	err2 = tb.MultiDel(context.Background(), []byte{}, nil)
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	err = tb.MultiDel(context.Background(), []byte{}, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	err = tb.Del(context.Background(), nil, nil)
-	assert.NotNil(t, err)
-	err2 = tb.Del(context.Background(), []byte{}, nil)
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	err = tb.Del(context.Background(), []byte{}, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
 	// === empty value === //
 
-	err = tb.SetTTL(context.Background(), []byte("h1"), nil, nil, 0)
-	assert.NotNil(t, err)
-	err2 = tb.Set(context.Background(), []byte("h1"), nil, []byte{})
-	assert.Equal(t, err, err2)
+	err = tb.SetTTL(context.Background(), []byte("h1"), []byte(""), nil, 0)
+	assert.Contains(t, err.Error(), "value must not be nil")
 
-	err = tb.MultiSet(context.Background(), []byte("h1"), [][]byte{}, nil)
-	assert.NotNil(t, err)
-	err2 = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{}, [][]byte{}, 0)
-	assert.Equal(t, err, err2)
+	err = tb.SetTTL(context.Background(), []byte("h1"), []byte(""), []byte(""), 0)
+	assert.Nil(t, err)
 
-	err = tb.MultiSet(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{nil})
-	assert.NotNil(t, err)
-	err2 = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{[]byte{}}, 0)
-	assert.Equal(t, err, err2)
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, nil, 0)
+	assert.Contains(t, err.Error(), "values must not be nil")
+
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{}, 0)
+	assert.Contains(t, err.Error(), "values must not be empty")
+
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{nil}, 0)
+	assert.Contains(t, err.Error(), "values[0] must not be nil")
+
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{[]byte("")}, 0)
+	assert.Nil(t, err)
 
 	// === empty sortkeys === //
 
 	err = tb.MultiSet(context.Background(), []byte("h1"), nil, [][]byte{[]byte("v1")})
-	assert.NotNil(t, err)
-	err2 = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{}, [][]byte{[]byte("v1")}, 0)
-	assert.Equal(t, err, err2)
+	assert.Contains(t, err.Error(), "sortkeys must not be nil")
+
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{}, [][]byte{[]byte("v1")}, 0)
+	assert.Contains(t, err.Error(), "sortkeys must not be empty")
+
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{nil}, [][]byte{[]byte("v1")}, 0)
+	assert.Contains(t, err.Error(), "sortkeys[0] must not be nil")
+
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("")}, [][]byte{[]byte("v1")}, 0)
+	assert.Nil(t, err)
 
 	err = tb.MultiDel(context.Background(), []byte("h1"), nil)
-	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "sortkeys must not be nil")
+
+	err = tb.MultiDel(context.Background(), []byte("h1"), [][]byte{})
+	assert.Contains(t, err.Error(), "sortkeys must not be empty")
+
+	_, _, err = tb.MultiGet(context.Background(), []byte("h1"), nil)
+	assert.Contains(t, err.Error(), "sortkeys must not be nil")
+	_, _, err = tb.MultiGetOpt(context.Background(), []byte("h1"), [][]byte{}, &MultiGetOptions{})
+	assert.Contains(t, err.Error(), "sortkeys must not be empty")
+
+	// === empty sortkey === //
+
+	err = tb.MultiSet(context.Background(), []byte("h1"), [][]byte{nil}, [][]byte{[]byte("v1")})
+	assert.Contains(t, err.Error(), "sortkeys[0] must not be nil")
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("")}, [][]byte{[]byte("v1")}, 0)
+	assert.Nil(t, err)
+
+	err = tb.SetTTL(context.Background(), []byte("h1"), nil, []byte(""), 0)
+	assert.Contains(t, err.Error(), "sortkey must not be nil")
+
+	_, err = tb.Get(context.Background(), []byte("h1"), nil)
+	assert.Contains(t, err.Error(), "sortkey must not be nil")
+
+	_, err = tb.TTL(context.Background(), []byte("h1"), nil)
+	assert.Contains(t, err.Error(), "sortkey must not be nil")
+
+	err = tb.Del(context.Background(), []byte("h1"), nil)
+	assert.Contains(t, err.Error(), "sortkey must not be nil")
 }
 
 func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -356,7 +356,7 @@ func testMultiKeyOperations(t *testing.T, tb TableConnector) {
 		// make sortKeys sorted.
 		sidBuf := []byte(fmt.Sprintf("%d", i))
 		var sidWithLeadingZero bytes.Buffer
-		for i := 0; i < 20-len(sidBuf); i++ {
+		for k := 0; k < 20-len(sidBuf); k++ {
 			sidWithLeadingZero.WriteByte('0')
 		}
 		sidWithLeadingZero.Write(sidBuf)
@@ -606,8 +606,8 @@ func TestPegasusTableConnector_ScanExclusive(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	for {
-		completed, h, s, v, err := scanner.Next(ctx)
-		assert.Nil(t, err)
+		completed, h, s, v, err2 := scanner.Next(ctx)
+		assert.Nil(t, err2)
 		if completed {
 			break
 		}

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -366,6 +366,8 @@ func testMultiKeyOperations(t *testing.T, tb TableConnector) {
 
 	// clear keyspace
 	results, allFetched, err := tb.MultiGetRange(context.Background(), hashKey, nil, nil)
+	assert.Nil(t, err)
+	assert.True(t, allFetched)
 	for _, result := range results {
 		assert.Nil(t, tb.Del(context.Background(), hashKey, result.SortKey))
 	}
@@ -617,7 +619,7 @@ func TestPegasusTableConnector_ScanExclusive(t *testing.T) {
 	scanner.Close()
 
 	err = cutAndCompareMaps(t, dataMap, baseMap["h1"], start, false, stop, false)
-	//fmt.Println(err.Error()) if can't cut the baseMap, abandon compare
+	assert.Nil(t, err)
 }
 
 func TestPegasusTableConnector_ScanOnePoint(t *testing.T) {
@@ -1000,6 +1002,7 @@ func TestPegasusTableConnector_CheckAndSet(t *testing.T) {
 
 	{ // check sortkey and set sortkey are different
 		results, _, err := tb.MultiGetRange(context.Background(), []byte("h1"), nil, nil)
+		assert.Nil(t, err)
 		for _, result := range results {
 			assert.Nil(t, tb.Del(context.Background(), []byte("h1"), result.SortKey))
 		}

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -118,117 +118,97 @@ func TestPegasusTableConnector_EmptyInput(t *testing.T) {
 	assert.Nil(t, err)
 	defer tb.Close()
 
-	// === empty hashkey === //
-
-	_, err = tb.TTL(context.Background(), nil, nil)
-	assert.Contains(t, err.Error(), "hashkey must not be nil")
-	_, err = tb.TTL(context.Background(), []byte{}, nil)
-	assert.Contains(t, err.Error(), "hashkey must not be empty")
-
-	_, err = tb.Exist(context.Background(), nil, nil)
-	assert.Contains(t, err.Error(), "hashkey must not be nil")
-	_, err = tb.Exist(context.Background(), []byte{}, nil)
-	assert.Contains(t, err.Error(), "hashkey must not be empty")
-
-	err = tb.SetTTL(context.Background(), nil, nil, nil, 0)
-	assert.Contains(t, err.Error(), "hashkey must not be nil")
-	err = tb.Set(context.Background(), []byte{}, nil, nil)
-	assert.Contains(t, err.Error(), "hashkey must not be empty")
-
+	// Get
 	_, err = tb.Get(context.Background(), nil, nil)
 	assert.Contains(t, err.Error(), "hashkey must not be nil")
 	_, err = tb.Get(context.Background(), []byte{}, nil)
 	assert.Contains(t, err.Error(), "hashkey must not be empty")
+	_, err = tb.Get(context.Background(), []byte("h1"), nil)
+	assert.Contains(t, err.Error(), "sortkey must not be nil")
+	_, err = tb.Get(context.Background(), []byte("h1"), []byte(""))
+	assert.Nil(t, err)
 
+	// Set
+	err = tb.SetTTL(context.Background(), nil, nil, nil, 0)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	err = tb.Set(context.Background(), []byte{}, nil, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
+	err = tb.SetTTL(context.Background(), []byte("h1"), nil, []byte(""), 0)
+	assert.Contains(t, err.Error(), "sortkey must not be nil")
+	err = tb.SetTTL(context.Background(), []byte("h1"), []byte(""), nil, 0)
+	assert.Contains(t, err.Error(), "value must not be nil")
+	err = tb.SetTTL(context.Background(), []byte("h1"), []byte(""), []byte(""), 0)
+	assert.Nil(t, err)
+
+	// Del
+	err = tb.Del(context.Background(), nil, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	err = tb.Del(context.Background(), []byte{}, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
+	err = tb.Del(context.Background(), []byte("h1"), nil)
+	assert.Contains(t, err.Error(), "sortkey must not be nil")
+	err = tb.Del(context.Background(), []byte("h1"), []byte(""))
+	assert.Nil(t, err)
+
+	// MultiGet
 	_, _, err = tb.MultiGet(context.Background(), nil, nil)
 	assert.Contains(t, err.Error(), "hashkey must not be nil")
 	_, _, err = tb.MultiGetOpt(context.Background(), []byte{}, nil, &MultiGetOptions{})
 	assert.Contains(t, err.Error(), "hashkey must not be empty")
+	_, _, err = tb.MultiGet(context.Background(), []byte("h1"), nil)
+	assert.Nil(t, err)
+	_, _, err = tb.MultiGetOpt(context.Background(), []byte("h1"), [][]byte{}, &MultiGetOptions{})
+	assert.Nil(t, err)
+	_, _, err = tb.MultiGetOpt(context.Background(), []byte("h1"), [][]byte{nil}, &MultiGetOptions{})
+	assert.Contains(t, err.Error(), "sortkeys[0] must not be nil")
 
+	// MultiGetRange
 	_, _, err = tb.MultiGetRange(context.Background(), nil, nil, nil)
 	assert.Contains(t, err.Error(), "hashkey must not be nil")
 	_, _, err = tb.MultiGetRangeOpt(context.Background(), []byte{}, nil, nil, &MultiGetOptions{})
 	assert.Contains(t, err.Error(), "hashkey must not be empty")
 
+	// MultiSet
 	err = tb.MultiSet(context.Background(), nil, nil, nil)
 	assert.Contains(t, err.Error(), "hashkey must not be nil")
 	err = tb.MultiSetOpt(context.Background(), []byte{}, nil, nil, 0)
 	assert.Contains(t, err.Error(), "hashkey must not be empty")
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, nil, 0)
+	assert.Contains(t, err.Error(), "values must not be nil")
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{}, 0)
+	assert.Contains(t, err.Error(), "values must not be empty")
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{nil}, 0)
+	assert.Contains(t, err.Error(), "values[0] must not be nil")
+	err = tb.MultiSet(context.Background(), []byte("h1"), nil, [][]byte{[]byte("v1")})
+	assert.Contains(t, err.Error(), "sortkeys must not be nil")
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{}, [][]byte{[]byte("v1")}, 0)
+	assert.Contains(t, err.Error(), "sortkeys must not be empty")
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{nil}, [][]byte{[]byte("v1")}, 0)
+	assert.Contains(t, err.Error(), "sortkeys[0] must not be nil")
+	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("")}, [][]byte{[]byte("v1")}, 0)
+	assert.Nil(t, err)
 
+	// MultiDel
 	err = tb.MultiDel(context.Background(), nil, nil)
 	assert.Contains(t, err.Error(), "hashkey must not be nil")
 	err = tb.MultiDel(context.Background(), []byte{}, nil)
 	assert.Contains(t, err.Error(), "hashkey must not be empty")
-
-	err = tb.Del(context.Background(), nil, nil)
-	assert.Contains(t, err.Error(), "hashkey must not be nil")
-	err = tb.Del(context.Background(), []byte{}, nil)
-	assert.Contains(t, err.Error(), "hashkey must not be empty")
-
-	// === empty value === //
-
-	err = tb.SetTTL(context.Background(), []byte("h1"), []byte(""), nil, 0)
-	assert.Contains(t, err.Error(), "value must not be nil")
-
-	err = tb.SetTTL(context.Background(), []byte("h1"), []byte(""), []byte(""), 0)
-	assert.Nil(t, err)
-
-	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, nil, 0)
-	assert.Contains(t, err.Error(), "values must not be nil")
-
-	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{}, 0)
-	assert.Contains(t, err.Error(), "values must not be empty")
-
-	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{nil}, 0)
-	assert.Contains(t, err.Error(), "values[0] must not be nil")
-
-	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("s1")}, [][]byte{[]byte("")}, 0)
-	assert.Nil(t, err)
-
-	// === empty sortkeys === //
-
-	err = tb.MultiSet(context.Background(), []byte("h1"), nil, [][]byte{[]byte("v1")})
-	assert.Contains(t, err.Error(), "sortkeys must not be nil")
-
-	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{}, [][]byte{[]byte("v1")}, 0)
-	assert.Contains(t, err.Error(), "sortkeys must not be empty")
-
-	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{nil}, [][]byte{[]byte("v1")}, 0)
-	assert.Contains(t, err.Error(), "sortkeys[0] must not be nil")
-
-	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("")}, [][]byte{[]byte("v1")}, 0)
-	assert.Nil(t, err)
-
 	err = tb.MultiDel(context.Background(), []byte("h1"), nil)
 	assert.Contains(t, err.Error(), "sortkeys must not be nil")
-
 	err = tb.MultiDel(context.Background(), []byte("h1"), [][]byte{})
 	assert.Contains(t, err.Error(), "sortkeys must not be empty")
-
-	_, _, err = tb.MultiGet(context.Background(), []byte("h1"), nil)
-	assert.Nil(t, err)
-
-	_, _, err = tb.MultiGetOpt(context.Background(), []byte("h1"), [][]byte{}, &MultiGetOptions{})
-	assert.Nil(t, err)
-
-	// === empty sortkey === //
-
-	err = tb.MultiSet(context.Background(), []byte("h1"), [][]byte{nil}, [][]byte{[]byte("v1")})
+	err = tb.MultiDel(context.Background(), []byte("h1"), [][]byte{nil})
 	assert.Contains(t, err.Error(), "sortkeys[0] must not be nil")
-	err = tb.MultiSetOpt(context.Background(), []byte("h1"), [][]byte{[]byte("")}, [][]byte{[]byte("v1")}, 0)
-	assert.Nil(t, err)
 
-	err = tb.SetTTL(context.Background(), []byte("h1"), nil, []byte(""), 0)
-	assert.Contains(t, err.Error(), "sortkey must not be nil")
-
-	_, err = tb.Get(context.Background(), []byte("h1"), nil)
-	assert.Contains(t, err.Error(), "sortkey must not be nil")
-
+	// TTL
+	_, err = tb.TTL(context.Background(), nil, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be nil")
+	_, err = tb.TTL(context.Background(), []byte{}, nil)
+	assert.Contains(t, err.Error(), "hashkey must not be empty")
 	_, err = tb.TTL(context.Background(), []byte("h1"), nil)
 	assert.Contains(t, err.Error(), "sortkey must not be nil")
-
-	err = tb.Del(context.Background(), []byte("h1"), nil)
-	assert.Contains(t, err.Error(), "sortkey must not be nil")
+	_, err = tb.TTL(context.Background(), []byte("h1"), []byte(""))
+	assert.Nil(t, err)
 }
 
 func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -254,9 +254,7 @@ func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {
 }
 
 func TestPegasusTableConnector_ValidateHashKey(t *testing.T) {
-	var hashKey []byte
-
-	hashKey = nil
+	hashKey := []byte(nil)
 	assert.NotNil(t, validateHashKey(hashKey))
 
 	hashKey = make([]byte, 0)
@@ -480,7 +478,7 @@ func TestPegasusTableConnector_ScanAllSortKey(t *testing.T) {
 
 	dataMap := make(map[string]string)
 	for {
-		err, completed, h, s, v := scanner.Next(context.Background())
+		completed, h, s, v, err := scanner.Next(context.Background())
 		assert.Nil(t, err)
 		if completed {
 			break
@@ -538,9 +536,10 @@ func TestPegasusTableConnector_ScanInclusive(t *testing.T) {
 	assert.Nil(t, err)
 
 	dataMap := make(map[string]string)
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
 	for {
-		err, completed, h, s, v := scanner.Next(ctx)
+		completed, h, s, v, err := scanner.Next(ctx)
 		assert.Nil(t, err)
 		if completed {
 			break
@@ -602,9 +601,10 @@ func TestPegasusTableConnector_ScanExclusive(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, scanner)
 	dataMap := make(map[string]string)
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
 	for {
-		err, completed, h, s, v := scanner.Next(ctx)
+		completed, h, s, v, err := scanner.Next(ctx)
 		assert.Nil(t, err)
 		if completed {
 			break
@@ -648,14 +648,14 @@ func TestPegasusTableConnector_ScanOnePoint(t *testing.T) {
 	options.StopInclusive = true
 	scanner, err := tb.GetScanner(context.Background(), []byte("h1"), start, start, options)
 	assert.Nil(t, err)
-	err, completed, h, s, v := scanner.Next(context.Background())
+	completed, h, s, v, err := scanner.Next(context.Background())
 	assert.Nil(t, err)
 	assert.False(t, completed)
 	assert.Equal(t, []byte("h1"), h)
 	assert.Equal(t, start, s)
 	assert.Equal(t, baseMap["h1"][string(start)], string(v))
 
-	err, completed, _, _, _ = scanner.Next(context.Background())
+	completed, _, _, _, err = scanner.Next(context.Background())
 	assert.Nil(t, err)
 	assert.True(t, completed)
 	scanner.Close()
@@ -760,7 +760,7 @@ func TestPegasusTableConnector_ScanOverallScan(t *testing.T) {
 	for _, s := range scanners {
 		assert.NotNil(t, s)
 		for {
-			err, completed, h, s, v := s.Next(context.Background())
+			completed, h, s, v, err := s.Next(context.Background())
 			assert.Nil(t, err)
 			if completed {
 				break
@@ -808,7 +808,7 @@ func TestPegasusTableConnector_ConcurrentCallScanner(t *testing.T) {
 
 		scanner := scanners[0]
 		for {
-			err, completed, h, s, v := scanner.Next(context.Background())
+			completed, h, s, v, err := scanner.Next(context.Background())
 			assert.Nil(t, err)
 			if completed {
 				break
@@ -850,9 +850,10 @@ func TestPegasusTableConnector_NoValueScan(t *testing.T) {
 	scanner, err := tb.GetScanner(context.Background(), []byte("h1"), []byte{}, []byte{}, options)
 	assert.Nil(t, err)
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
 	for {
-		err, completed, h, s, v := scanner.Next(ctx)
+		completed, h, s, v, err := scanner.Next(ctx)
 		assert.Nil(t, err)
 		if completed {
 			break
@@ -873,7 +874,7 @@ func clearDatabase(t *testing.T, tb TableConnector) {
 	assert.NotNil(t, scanners[0])
 
 	for {
-		err1, completed, h, s, _ := scanners[0].Next(context.Background())
+		completed, h, s, _, err1 := scanners[0].Next(context.Background())
 		assert.Nil(t, err1)
 		if completed {
 			break
@@ -888,7 +889,7 @@ func clearDatabase(t *testing.T, tb TableConnector) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(scanners))
 	assert.NotNil(t, scanners[0])
-	err, completed, _, _, _ := scanners[0].Next(context.Background())
+	completed, _, _, _, err := scanners[0].Next(context.Background())
 	assert.Nil(t, err)
 	assert.True(t, completed)
 }

--- a/pegasus/util.go
+++ b/pegasus/util.go
@@ -53,10 +53,10 @@ func crc64Hash(data []byte) uint64 {
 	return crc64.Checksum(data, crc64Table)
 }
 
-// 1451606400 means seconds since 2016.01.01-00:00:00 GMT
 func expireTsSeconds(ttl time.Duration) int32 {
 	if ttl == 0 {
 		return 0
 	}
+	// 1451606400 means seconds since 2016.01.01-00:00:00 GMT
 	return int32(ttl.Seconds()) + int32(time.Now().Unix()-1451606400)
 }


### PR DESCRIPTION
staticcheck, govet, golint are static checking tools in go like cpplint in c++.

```
cd pegasus

staticcheck
go vet
golint .
gosimple .
go tool vet -all -shadow .
```