### PR TITLE
fix hang problem when rpc session is rejected/closed by meta

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -239,7 +239,7 @@ func (n *nodeSession) loopForResponse() error {
 				}
 			} else {
 				n.logger.Printf("failed to read response from %s: %s", n, err)
-				return nil
+				return err
 			}
 		}
 


### PR DESCRIPTION
fix hang problem when rpc session is rejected/closed by meta due to connection threshold

2019/03/07 18:52:22 create session with [127.0.0.1:34601(meta)]
2019/03/07 18:52:22 create session with [127.0.0.1:34602(meta)]
2019/03/07 18:52:22 create session with [127.0.0.1:34603(meta)]
2019/03/07 18:52:27 open table
2019/03/07 18:52:27 querying configuration of table(temp) from [127.0.0.1:34601(meta)]
2019/03/07 18:52:27 stop dialing for [127.0.0.1:34601(meta)], connection state: ConnStateReady
**2019/03/07 18:52:27 failed to read response from [127.0.0.1:34601(meta)]: EOF >>> hang up here if no err is returned**
2019/03/07 18:52:27 failed to query configuration from [127.0.0.1:34601(meta)]: session [127.0.0.1:34601(meta)] is not ready
2019/03/07 18:52:27 querying configuration of table(temp) from [127.0.0.1:34602(meta)]
2019/03/07 18:52:27 stop dialing for [127.0.0.1:34602(meta)], connection state: ConnStateReady
2019/03/07 18:52:27 querying configuration of table(temp) from [127.0.0.1:34603(meta)]
2019/03/07 18:52:27 stop dialing for [127.0.0.1:34603(meta)], connection state: ConnStateReady
2019/03/07 18:52:27 wss: open table err = pegasus-go-client table configuration query failed: failed to connect table(temp): unable to find the leader of meta servers
2019/03/07 18:52:27 Close session with [127.0.0.1:34601(meta)]
2019/03/07 18:52:27 Close session with [127.0.0.1:34602(meta)]
2019/03/07 18:52:27 failed to read response from [127.0.0.1:34602(meta)]: read tcp 127.0.0.1:40516->127.0.0.1:34602: use of closed network connection
2019/03/07 18:52:27 Close session with [127.0.0.1:34603(meta)]
2019/03/07 18:52:27 failed to read response from [127.0.0.1:34603(meta)]: read tcp 127.0.0.1:44580->127.0.0.1:34603: use of closed network connection