### PR TITLE
fix: rpc blocked on loopForResponse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,1 @@
-# Created by .ignore support plugin (hsz.mobi)
-### Example user template template
-### Example user template
-
-# IntelliJ project files
-.idea
-*.iml
-out
-gen
+bin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 build:
 	go build -o ./bin/example ./example/main.go
+	go build -o ./bin/echo ./rpc/main/echo.go
 
 fmt:
 	go fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+build:
+	go build -o ./bin/example ./example/main.go
+
 fmt:
 	go fmt ./...
 

--- a/session/codec.go
+++ b/session/codec.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"time"
 
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
 	"github.com/XiaoMi/pegasus-go-client/idl/replication"
@@ -237,6 +238,18 @@ type PegasusRpcCall struct {
 	Gpid   *base.Gpid
 	RawReq []byte // the marshalled request in bytes
 	Err    error
+
+	// hooks on each stage during rpc processing
+	OnRpcCall time.Time
+	OnRpcSend time.Time
+	OnRpcRecv time.Time
+}
+
+func (call *PegasusRpcCall) Trace() string {
+	return fmt.Sprintf("call->%dus->send->%dus->recv->%dus->now",
+		call.OnRpcSend.Sub(call.OnRpcCall).Microseconds(),
+		call.OnRpcRecv.Sub(call.OnRpcSend).Microseconds(),
+		time.Since(call.OnRpcRecv).Microseconds())
 }
 
 func MarshallPegasusRpc(codec rpc.Codec, seqId int32, gpid *base.Gpid, args RpcRequestArgs, name string) (*PegasusRpcCall, error) {

--- a/session/session.go
+++ b/session/session.go
@@ -200,6 +200,7 @@ func (n *nodeSession) loopForRequest() error {
 			n.pendingResp[req.call.SeqId] = req
 			n.mu.Unlock()
 
+			req.call.OnRpcSend = time.Now()
 			if err := n.writeRequest(req.call); err != nil {
 				n.logger.Printf("failed to send request to %s: %s", n, err)
 
@@ -242,6 +243,7 @@ func (n *nodeSession) loopForResponse() error {
 				return err
 			}
 		}
+		call.OnRpcRecv = time.Now()
 
 		n.mu.Lock()
 		reqListener, ok := n.pendingResp[call.SeqId]
@@ -255,6 +257,7 @@ func (n *nodeSession) loopForResponse() error {
 
 		reqListener.call.Err = call.Err
 		reqListener.call.Result = call.Result
+		reqListener.call.OnRpcRecv = call.OnRpcRecv
 		n.notifyCallerAndDrop(reqListener)
 	}
 }
@@ -302,6 +305,7 @@ func (n *nodeSession) CallWithGpid(ctx context.Context, gpid *base.Gpid, args Rp
 	if err != nil {
 		return nil, err
 	}
+	rcall.OnRpcCall = time.Now()
 
 	req := &requestListener{call: rcall, ch: make(chan bool, 1)}
 
@@ -319,6 +323,7 @@ func (n *nodeSession) CallWithGpid(ctx context.Context, gpid *base.Gpid, args Rp
 		case <-req.ch:
 			err = rcall.Err
 			result = rcall.Result
+			fmt.Println(rcall.Trace())
 			return
 		case <-ctxWithTomb.Done():
 			err = ctxWithTomb.Err()


### PR DESCRIPTION
`loopForResponse`: there's a serious bug here. The goroutine sleeps 1 sec when no data to read from the session. But if there's incoming data during this 1sec, they must wait until the goroutine awakes. This will unacceptably cause high latency when the throughput is low.