### PR TITLE
fix: retry on replica failover until context timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/apache/thrift v0.13.0
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pegasus/client_test.go
+++ b/pegasus/client_test.go
@@ -26,11 +26,11 @@ func TestPegasusClient_OpenTable(t *testing.T) {
 	defer client.Close()
 
 	tb1, err := client.OpenTable(context.Background(), "temp")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, tb1)
 
 	tb2, err := client.OpenTable(context.Background(), "temp")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, tb1)
 
 	// must reuse previous connection
@@ -40,7 +40,8 @@ func TestPegasusClient_OpenTable(t *testing.T) {
 	assert.NotNil(t, pclient.findTable("temp"))
 
 	tb, err := client.OpenTable(context.Background(), "table_not_exists")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ERR_OBJECT_NOT_FOUND")
 	assert.Nil(t, tb)
 }
 

--- a/pegasus/retry_failover.go
+++ b/pegasus/retry_failover.go
@@ -31,6 +31,7 @@ type tableRPCOp func() (confUpdated bool, result interface{}, err error)
 // retryFailOver retries the operation when it encounters replica fail-over, until context reaches deadline.
 func retryFailOver(ctx context.Context, op tableRPCOp) (interface{}, error) {
 	bf := backoff.NewExponentialBackOff()
+	bf.InitialInterval = time.Second
 	bf.Multiplier = 2
 	for {
 		confUpdated, res, err := op()

--- a/pegasus/retry_failover.go
+++ b/pegasus/retry_failover.go
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package pegasus
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+type tableRPCOp func() (confUpdated bool, result interface{}, err error)
+
+// retryFailOver retries the operation when it encounters replica fail-over, until context reaches deadline.
+func retryFailOver(ctx context.Context, op tableRPCOp) (interface{}, error) {
+	bf := backoff.NewExponentialBackOff()
+	bf.Multiplier = 2
+	for {
+		confUpdated, res, err := op()
+		ticker := time.NewTicker(bf.NextBackOff())
+		if confUpdated { // must fail
+			select {
+			case <-ticker.C:
+				continue
+			case <-ctx.Done():
+				err = ctx.Err()
+				break
+			}
+		}
+		return res, err
+	}
+}

--- a/pegasus/retry_failover_test.go
+++ b/pegasus/retry_failover_test.go
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package pegasus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/XiaoMi/pegasus-go-client/idl/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryFailOver_Success(t *testing.T) {
+	// success, no retry
+	times := 0
+	_, err := retryFailOver(context.Background(), func() (confUpdated bool, result interface{}, err error) {
+		times++
+		return false, nil, nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, times, 1)
+}
+
+func TestRetryFailOver_FailureNoRetry(t *testing.T) {
+	// first try fails, but it shouldn't retry
+	times := 0
+	_, err := retryFailOver(context.Background(), func() (confUpdated bool, result interface{}, err error) {
+		times++
+		return false, nil, context.DeadlineExceeded
+	})
+	assert.Error(t, err)
+	assert.Equal(t, times, 1)
+}
+
+func TestRetryFailOver_FailureRetryWithIncreasingInterval(t *testing.T) {
+	// fail 2 times, success at the 3rd attempt
+	start := time.Now()
+	var elapses []time.Duration
+	_, err := retryFailOver(context.Background(), func() (confUpdated bool, result interface{}, err error) {
+		elapses = append(elapses, time.Since(start))
+		start = time.Now()
+		if len(elapses) > 5 {
+			return false, nil, nil
+		}
+		return true, nil, base.ERR_OBJECT_NOT_FOUND
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, len(elapses), 6)
+	for i := 1; i < len(elapses); i++ {
+		assert.GreaterOrEqual(t, int64(elapses[i]), int64(elapses[i-1]))
+	}
+}
+
+func TestRetryFailOver_FailureRetryUntilTimeout(t *testing.T) {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	res, err := retryFailOver(ctx, func() (confUpdated bool, result interface{}, err error) {
+		return true, nil, base.ERR_OBJECT_NOT_FOUND
+	})
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.Equal(t, err, context.DeadlineExceeded)
+	assert.Nil(t, res)
+	assert.GreaterOrEqual(t, int64(elapsed), int64(time.Second*5))
+}

--- a/pegasus/retry_failover_test.go
+++ b/pegasus/retry_failover_test.go
@@ -50,7 +50,7 @@ func TestRetryFailOver_FailureNoRetry(t *testing.T) {
 }
 
 func TestRetryFailOver_FailureRetryWithIncreasingInterval(t *testing.T) {
-	// fail 2 times, success at the 3rd attempt
+	// fail n times, success at the (n+1)th attempt
 	start := time.Now()
 	var elapses []time.Duration
 	_, err := retryFailOver(context.Background(), func() (confUpdated bool, result interface{}, err error) {
@@ -63,8 +63,9 @@ func TestRetryFailOver_FailureRetryWithIncreasingInterval(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, len(elapses), 6)
-	for i := 1; i < len(elapses); i++ {
-		assert.GreaterOrEqual(t, int64(elapses[i]), int64(elapses[i-1]))
+	for i := 4; i < len(elapses); i++ {
+		// ensure the backoff interval is basically increasing
+		assert.GreaterOrEqual(t, int64(elapses[i]), int64(elapses[1]))
 	}
 }
 

--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -688,7 +688,6 @@ func (p *pegasusTableConnector) handleReplicaError(err error, replica *session.R
 			p.tryConfUpdate(err, replica)
 		}
 
-		// add gpid and remote address to error
 		return confUpdate, err
 	}
 	return false, nil

--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -311,6 +311,20 @@ func WrapError(err error, op OpType) error {
 	return nil
 }
 
+func (p *pegasusTableConnector) wrapPartitionError(err error, gpid *base.Gpid, replica *session.ReplicaSession, opType OpType) error {
+	err = WrapError(err, opType)
+	if err == nil {
+		return nil
+	}
+	perr := err.(*PError)
+	if perr.Err != nil {
+		perr.Err = fmt.Errorf("%s [%s, %s, table=\"%s\"]", perr.Err, gpid, replica, p.tableName)
+	} else {
+		perr.Err = fmt.Errorf("[%s, %s, table=\"%s\"]", gpid, replica, p.tableName)
+	}
+	return perr
+}
+
 func (p *pegasusTableConnector) Get(ctx context.Context, hashKey []byte, sortKey []byte) ([]byte, error) {
 	res, err := p.runPartitionOp(ctx, hashKey, &op.Get{HashKey: hashKey, SortKey: sortKey}, OpGet)
 	if err != nil {
@@ -569,19 +583,17 @@ func (p *pegasusTableConnector) Incr(ctx context.Context, hashKey []byte, sortKe
 }
 
 func (p *pegasusTableConnector) runPartitionOp(ctx context.Context, hashKey []byte, req op.Request, optype OpType) (interface{}, error) {
-	res, err := func() (interface{}, error) {
-		// validate arguments
-		if err := req.Validate(); err != nil {
-			return 0, err
-		}
-		gpid, part := p.getPartition(hashKey)
-		res, err := req.Run(ctx, gpid, part)
-		if err = p.handleReplicaError(err, gpid, part); err != nil {
-			return nil, err
-		}
-		return res, nil
-	}()
-	return res, WrapError(err, optype)
+	// validate arguments
+	if err := req.Validate(); err != nil {
+		return 0, WrapError(err, optype)
+	}
+	gpid, part := p.getPartition(hashKey)
+	res, err := retryFailOver(ctx, func() (confUpdated bool, result interface{}, err error) {
+		result, err = req.Run(ctx, gpid, part)
+		confUpdated, err = p.handleReplicaError(err, part)
+		return
+	})
+	return res, p.wrapPartitionError(err, gpid, part, optype)
 }
 
 func (p *pegasusTableConnector) BatchGet(ctx context.Context, keys []CompositeKey) (values [][]byte, err error) {
@@ -637,17 +649,18 @@ func (p *pegasusTableConnector) Close() error {
 	return nil
 }
 
-func (p *pegasusTableConnector) handleReplicaError(err error, gpid *base.Gpid, replica *session.ReplicaSession) error {
+func (p *pegasusTableConnector) handleReplicaError(err error, replica *session.ReplicaSession) (bool, error) {
 	if err != nil {
 		confUpdate := false
 
 		switch err {
 		case base.ERR_OK:
 			// should not happen
-			return nil
+			return false, nil
 
 		case base.ERR_TIMEOUT:
 		case context.DeadlineExceeded:
+		case context.Canceled:
 			// timeout will not trigger a configuration update
 
 		case base.ERR_NOT_ENOUGH_MEMBER:
@@ -676,15 +689,9 @@ func (p *pegasusTableConnector) handleReplicaError(err error, gpid *base.Gpid, r
 		}
 
 		// add gpid and remote address to error
-		perr := WrapError(err, 0).(*PError)
-		if perr.Err != nil {
-			perr.Err = fmt.Errorf("%s [%s, %s, table=\"%s\"]", perr.Err, gpid, replica, p.tableName)
-		} else {
-			perr.Err = fmt.Errorf("[%s, %s, table=\"%s\"]", gpid, replica, p.tableName)
-		}
-		return perr
+		return confUpdate, err
 	}
-	return nil
+	return false, nil
 }
 
 // tryConfUpdate makes an attempt to update table configuration by querying meta server.

--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -665,7 +665,6 @@ func (p *pegasusTableConnector) handleReplicaError(err error, replica *session.R
 
 		case base.ERR_NOT_ENOUGH_MEMBER:
 		case base.ERR_CAPACITY_EXCEEDED:
-			// confUpdate later
 
 		case base.ERR_BUSY:
 			// throttled by server, skip confUpdate

--- a/pegasus/table_connector.go
+++ b/pegasus/table_connector.go
@@ -318,9 +318,9 @@ func (p *pegasusTableConnector) wrapPartitionError(err error, gpid *base.Gpid, r
 	}
 	perr := err.(*PError)
 	if perr.Err != nil {
-		perr.Err = fmt.Errorf("%s [%s, %s, table=\"%s\"]", perr.Err, gpid, replica, p.tableName)
+		perr.Err = fmt.Errorf("%s [%s, %s, table=%s]", perr.Err, gpid, replica, p.tableName)
 	} else {
-		perr.Err = fmt.Errorf("[%s, %s, table=\"%s\"]", gpid, replica, p.tableName)
+		perr.Err = fmt.Errorf("[%s, %s, table=%s]", gpid, replica, p.tableName)
 	}
 	return perr
 }

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -221,21 +221,21 @@ func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {
 		logger:       pegalog.GetLogger(),
 	}
 
-	confUpdate, err := ptb.handleReplicaError(nil, nil, nil) // no error
+	confUpdate, err := ptb.handleReplicaError(nil, nil) // no error
 	assert.NoError(t, err)
 	assert.False(t, confUpdate)
 
-	confUpdate, err = ptb.handleReplicaError(errors.New("not nil"), nil, nil) // unknown error
-	<-ptb.confUpdateCh                                                        // must trigger confUpdate
+	confUpdate, err = ptb.handleReplicaError(errors.New("not nil"), nil) // unknown error
+	<-ptb.confUpdateCh                                                   // must trigger confUpdate
 	assert.Error(t, err)
 	assert.True(t, confUpdate)
 
-	confUpdate, err = ptb.handleReplicaError(base.ERR_OBJECT_NOT_FOUND, nil, nil)
+	confUpdate, err = ptb.handleReplicaError(base.ERR_OBJECT_NOT_FOUND, nil)
 	<-ptb.confUpdateCh
 	assert.Error(t, err)
 	assert.True(t, confUpdate)
 
-	confUpdate, err = ptb.handleReplicaError(base.ERR_INVALID_STATE, nil, nil)
+	confUpdate, err = ptb.handleReplicaError(base.ERR_INVALID_STATE, nil)
 	<-ptb.confUpdateCh
 	assert.Error(t, err)
 	assert.True(t, confUpdate)
@@ -245,7 +245,7 @@ func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {
 
 		for _, err := range errorTypes {
 			channelEmpty := false
-			confUpdate, err = ptb.handleReplicaError(err, nil, nil)
+			confUpdate, err = ptb.handleReplicaError(err, nil)
 			select {
 			case <-ptb.confUpdateCh:
 			default:

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -221,30 +221,40 @@ func TestPegasusTableConnector_TriggerSelfUpdate(t *testing.T) {
 		logger:       pegalog.GetLogger(),
 	}
 
-	err := ptb.handleReplicaError(nil, nil, nil) // no error
-	assert.Nil(t, err)
+	confUpdate, err := ptb.handleReplicaError(nil, nil, nil) // no error
+	assert.NoError(t, err)
+	assert.False(t, confUpdate)
 
-	ptb.handleReplicaError(errors.New("not nil"), nil, nil) // unknown error
-	<-ptb.confUpdateCh                                      // must trigger confUpdate
+	confUpdate, err = ptb.handleReplicaError(errors.New("not nil"), nil, nil) // unknown error
+	<-ptb.confUpdateCh                                                        // must trigger confUpdate
+	assert.Error(t, err)
+	assert.True(t, confUpdate)
 
-	ptb.handleReplicaError(base.ERR_OBJECT_NOT_FOUND, nil, nil)
+	confUpdate, err = ptb.handleReplicaError(base.ERR_OBJECT_NOT_FOUND, nil, nil)
 	<-ptb.confUpdateCh
+	assert.Error(t, err)
+	assert.True(t, confUpdate)
 
-	ptb.handleReplicaError(base.ERR_INVALID_STATE, nil, nil)
+	confUpdate, err = ptb.handleReplicaError(base.ERR_INVALID_STATE, nil, nil)
 	<-ptb.confUpdateCh
+	assert.Error(t, err)
+	assert.True(t, confUpdate)
 
 	{ // Ensure: The following errors should not trigger configuration update
 		errorTypes := []error{base.ERR_TIMEOUT, context.DeadlineExceeded, base.ERR_CAPACITY_EXCEEDED, base.ERR_NOT_ENOUGH_MEMBER, base.ERR_BUSY}
 
 		for _, err := range errorTypes {
 			channelEmpty := false
-			ptb.handleReplicaError(err, nil, nil)
+			confUpdate, err = ptb.handleReplicaError(err, nil, nil)
 			select {
 			case <-ptb.confUpdateCh:
 			default:
 				channelEmpty = true
 			}
 			assert.True(t, channelEmpty)
+
+			assert.Error(t, err)
+			assert.False(t, confUpdate)
 		}
 	}
 }


### PR DESCRIPTION
Previously, during replica failover, the client will return `ERR_OBJECT_NOT_FOUND` or `ERR_INVALID_STATE` directly to users, which indicates that the replica was migrated to another node.

This is a case we did not handle well. Because from the user's perspective, the client should automatically retry and hide the fail-over details from them. So this PR implements this kind of error handling, reduce the errors count as much as possible.

The current retry policy is nearly endless backoff retry (`MaxRetryInterval` is 60s) until context timeout.

## Manual test

In our previous version, the client fails with log:

```
time="2021-03-16T19:39:52+08:00" level=info msg="pegasus SET failed: session [10.231.57.99:34801(replica)] is unable to connect within 1000ms [{Appid:2 PartitionIndex:1}, [10.231.57.99:34801(replica)], table=\"temp\"]" func="logrus.(*Entry).Info" file="entry.go:285"
```

Or

```
time="2021-03-16T19:43:08+08:00" level=info msg="pegasus SET failed: [ERR_INVALID_STATE] The target replica is not primary [{Appid:2 PartitionIndex:1}, [10.231.57.99:34803(replica)], table=\"temp\"]" func="logrus.(*Entry).Info" file="entry.go:285"
```

Now, the client always fails with timeout only:

```
time="2021-03-16T19:07:59+08:00" level=info msg="pegasus SET failed: context deadline exceeded [{Appid:2 PartitionIndex:0}, [10.231.57.99:34801(replica)], table=\"temp\"]" func="logrus.(*Entry).Info" file="entry.go:285"
```
