### PR TITLE
build: shade dependencies of thrift

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "session/admin_rpc_types.go"
+  - "session/radmin_rpc_types.go"
+  - "idl/**"

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/apache/thrift v0.13.0
 	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/fortytw2/leaktest v1.3.0
+	github.com/pegasus-kv/thrift v0.13.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20191105084925-a882066a44e0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
-github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -62,6 +60,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/pegasus-kv/thrift v0.13.0 h1:4ESwaNoHImfbHa9RUGJiJZ4hrxorihZHk5aarYwY8d4=
+github.com/pegasus-kv/thrift v0.13.0/go.mod h1:Gl9NT/WHG6ABm6NsrbfE8LiJN0sAyneCrvB4qN4NPqQ=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/idl/admin/admin-consts.go
+++ b/idl/admin/admin-consts.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/idl/admin/admin.go
+++ b/idl/admin/admin.go
@@ -12,7 +12,7 @@ import (
 	"reflect"
 
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/idl/base/blob.go
+++ b/idl/base/blob.go
@@ -7,7 +7,7 @@ package base
 import (
 	"fmt"
 
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 )
 
 type Blob struct {

--- a/idl/base/error_code.go
+++ b/idl/base/error_code.go
@@ -3,7 +3,7 @@ package base
 import (
 	"fmt"
 
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 )
 
 /// Primitive for Pegasus thrift framework.

--- a/idl/base/gpid.go
+++ b/idl/base/gpid.go
@@ -7,7 +7,7 @@ package base
 import (
 	"fmt"
 
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 )
 
 type Gpid struct {

--- a/idl/base/gpid_test.go
+++ b/idl/base/gpid_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/XiaoMi/pegasus-go-client/pegalog"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/idl/base/rpc_address.go
+++ b/idl/base/rpc_address.go
@@ -9,7 +9,7 @@ import (
 
 	"net"
 
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 )
 
 type RPCAddress struct {

--- a/idl/cmd/cmd-consts.go
+++ b/idl/cmd/cmd-consts.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/idl/cmd/cmd.go
+++ b/idl/cmd/cmd.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/idl/radmin/radmin-consts.go
+++ b/idl/radmin/radmin-consts.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/idl/radmin/radmin.go
+++ b/idl/radmin/radmin.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/idl/replication/replication-consts.go
+++ b/idl/replication/replication-consts.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/idl/replication/replication.go
+++ b/idl/replication/replication.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/idl/rrdb/rrdb-consts.go
+++ b/idl/rrdb/rrdb-consts.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
 	"github.com/XiaoMi/pegasus-go-client/idl/replication"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/idl/rrdb/rrdb.go
+++ b/idl/rrdb/rrdb.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"github.com/XiaoMi/pegasus-go-client/idl/base"
 	"github.com/XiaoMi/pegasus-go-client/idl/replication"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"reflect"
 )
 

--- a/session/codec.go
+++ b/session/codec.go
@@ -19,7 +19,7 @@ import (
 	"github.com/XiaoMi/pegasus-go-client/idl/rrdb"
 	"github.com/XiaoMi/pegasus-go-client/pegalog"
 	"github.com/XiaoMi/pegasus-go-client/rpc"
-	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 )
 
 type PegasusCodec struct {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/XiaoMi/pegasus-go-client/idl/rrdb"
 	"github.com/XiaoMi/pegasus-go-client/pegalog"
 	"github.com/XiaoMi/pegasus-go-client/rpc"
-	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/fortytw2/leaktest"
+	"github.com/pegasus-kv/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Users depending on other versions of github.com/apache/thrift will conflict with ours (0.13.0). To avoid this problem, I created a fork of apache/thrift to pegasus-kv/thrift. Now go-client will entirely use a package that's exclusive for us, never gonna meet the conflict.
