### PR TITLE
fix: block on session close

### DIFF
--- a/pegasus/client.go
+++ b/pegasus/client.go
@@ -70,7 +70,7 @@ func (p *pegasusClient) Close() error {
 	}
 
 	if err := p.metaMgr.Close(); err != nil {
-		pegalog.GetLogger().Fatal("pegasus-go-client: unable to close metaMgr: ", err)
+		pegalog.GetLogger().Fatal("pegasus-go-client: unable to close MetaManager: ", err)
 	}
 	return p.replicaMgr.Close()
 }

--- a/pegasus/table_connector_leak_test.go
+++ b/pegasus/table_connector_leak_test.go
@@ -1,0 +1,26 @@
+package pegasus
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPegasusTableConnector_CloseMustNotLeak(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	for i := 0; i < 20; i++ {
+		client := NewClient(testingCfg)
+		defer client.Close()
+
+		tb, err := client.OpenTable(context.Background(), "temp")
+		assert.Nil(t, err)
+		defer tb.Close()
+
+		_, err = tb.Get(context.Background(), []byte(fmt.Sprintf("%d", i)), []byte("sortkey"))
+		assert.Nil(t, err)
+	}
+}

--- a/pegasus/table_connector_leak_test.go
+++ b/pegasus/table_connector_leak_test.go
@@ -14,13 +14,13 @@ func TestPegasusTableConnector_CloseMustNotLeak(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		client := NewClient(testingCfg)
-		defer client.Close()
 
 		tb, err := client.OpenTable(context.Background(), "temp")
 		assert.Nil(t, err)
-		defer tb.Close()
 
 		_, err = tb.Get(context.Background(), []byte(fmt.Sprintf("%d", i)), []byte("sortkey"))
 		assert.Nil(t, err)
+
+		client.Close()
 	}
 }

--- a/pegasus/table_connector_leak_test.go
+++ b/pegasus/table_connector_leak_test.go
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package pegasus
 
 import (

--- a/pegasus/table_connector_test.go
+++ b/pegasus/table_connector_test.go
@@ -110,6 +110,8 @@ func TestPegasusTableConnector_SingleKeyOperations(t *testing.T) {
 }
 
 func TestPegasusTableConnector_EmptyInput(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	client := NewClient(testingCfg)
 	defer client.Close()
 

--- a/session/session.go
+++ b/session/session.go
@@ -89,7 +89,6 @@ func withUnresponsiveHandler(s NodeSession, handler UnresponsiveHandler) {
 		return
 	}
 	ns.unresponsiveHandler = handler
-	return
 }
 
 type requestListener struct {

--- a/session/session.go
+++ b/session/session.go
@@ -387,13 +387,12 @@ func (n *nodeSession) readResponse() (*PegasusRpcCall, error) {
 
 func (n *nodeSession) Close() error {
 	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	if n.ConnState() != rpc.ConnStateClosed {
 		n.logger.Printf("close session %s", n)
 		n.conn.Close()
 		n.tom.Kill(errors.New("nodeSession closed"))
 	}
+	n.mu.Unlock()
 
 	return n.tom.Wait()
 }

--- a/session/session.go
+++ b/session/session.go
@@ -6,7 +6,6 @@ package session
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -390,7 +389,7 @@ func (n *nodeSession) Close() error {
 	if n.ConnState() != rpc.ConnStateClosed {
 		n.logger.Printf("close session %s", n)
 		n.conn.Close()
-		n.tom.Kill(errors.New("nodeSession closed"))
+		n.tom.Kill(nil)
 	}
 	n.mu.Unlock()
 

--- a/session/session.go
+++ b/session/session.go
@@ -395,6 +395,5 @@ func (n *nodeSession) Close() error {
 		n.tom.Kill(errors.New("nodeSession closed"))
 	}
 
-	<-n.tom.Dead()
-	return nil
+	return n.tom.Wait()
 }


### PR DESCRIPTION
On our experience debugging (using `delve`) go-client, we found it sometimes blocks on the function `nodeSession#Close()`, where it tries to wait for the `n.tom.dead` channel to signal completion. But this somehow does not work as expected.

After using `n.tom.Wait()` instead, it really solves the problem of blocking. At least the problem has not occurred again now.